### PR TITLE
docs fix - link to py3 docs instead of py2

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -291,7 +291,7 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'https://docs.python.org/2/': None,
+    'https://docs.python.org/3/': None,
     'http://bokeh.pydata.org/en/0.12.1/': None
 }
 

--- a/docs/source/pypi_download_stats.dataquery.rst
+++ b/docs/source/pypi_download_stats.dataquery.rst
@@ -1,5 +1,5 @@
-pypi\_download\_stats\.dataquery module
-=======================================
+pypi\_download\_stats.dataquery module
+======================================
 
 .. automodule:: pypi_download_stats.dataquery
     :members:

--- a/docs/source/pypi_download_stats.diskdatacache.rst
+++ b/docs/source/pypi_download_stats.diskdatacache.rst
@@ -1,5 +1,5 @@
-pypi\_download\_stats\.diskdatacache module
-===========================================
+pypi\_download\_stats.diskdatacache module
+==========================================
 
 .. automodule:: pypi_download_stats.diskdatacache
     :members:

--- a/docs/source/pypi_download_stats.graphs.rst
+++ b/docs/source/pypi_download_stats.graphs.rst
@@ -1,5 +1,5 @@
-pypi\_download\_stats\.graphs module
-====================================
+pypi\_download\_stats.graphs module
+===================================
 
 .. automodule:: pypi_download_stats.graphs
     :members:

--- a/docs/source/pypi_download_stats.outputgenerator.rst
+++ b/docs/source/pypi_download_stats.outputgenerator.rst
@@ -1,5 +1,5 @@
-pypi\_download\_stats\.outputgenerator module
-=============================================
+pypi\_download\_stats.outputgenerator module
+============================================
 
 .. automodule:: pypi_download_stats.outputgenerator
     :members:

--- a/docs/source/pypi_download_stats.projectstats.rst
+++ b/docs/source/pypi_download_stats.projectstats.rst
@@ -1,5 +1,5 @@
-pypi\_download\_stats\.projectstats module
-==========================================
+pypi\_download\_stats.projectstats module
+=========================================
 
 .. automodule:: pypi_download_stats.projectstats
     :members:

--- a/docs/source/pypi_download_stats.runner.rst
+++ b/docs/source/pypi_download_stats.runner.rst
@@ -1,5 +1,5 @@
-pypi\_download\_stats\.runner module
-====================================
+pypi\_download\_stats.runner module
+===================================
 
 .. automodule:: pypi_download_stats.runner
     :members:

--- a/docs/source/pypi_download_stats.version.rst
+++ b/docs/source/pypi_download_stats.version.rst
@@ -1,5 +1,5 @@
-pypi\_download\_stats\.version module
-=====================================
+pypi\_download\_stats.version module
+====================================
 
 .. automodule:: pypi_download_stats.version
     :members:


### PR DESCRIPTION
This fixes the failing sphinx docs build by switching the upstream python docs we cross-reference from 2 to 3.